### PR TITLE
Add KeepRule to Learning materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feel free to contribute.
 
 ### Learning materials
 - [Investopedia university](https://www.investopedia.com/university/) - Great library full of knowledge and explainer videos
-
+- [KeepRule](https://keeprule.com) - Free database of 1,377 investment principles from 26 legendary investors (Buffett, Munger, Graham, Dalio). AI chat, psychology tests, and deep-dive strategy articles.
 ### General tools
 - [PolarNote](https://polarnote.ai) - Investing note-taking, second brain for investment notes, watchlist and portfolio. AI live analysis.
 - [Ghostfolio](https://ghostfol.io) - Open source wealth management software to keep track of stocks, ETFs or cryptocurrencies and make solid, data-driven investment decisions.


### PR DESCRIPTION
## What is KeepRule?

[KeepRule](https://keeprule.com/) is a free investment education platform featuring:

- **1,300+ investment principles** from 27 legendary investors (Warren Buffett, Charlie Munger, Howard Marks, Ray Dalio, etc.)
- **95 scenario-based guides** for real-world investing decisions
- **Free investment psychology test** to help investors identify their cognitive biases

It fits naturally in the **Learning materials** section alongside Investopedia as an educational resource for stock investors.